### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/egranata/aria/security/code-scanning/1](https://github.com/egranata/aria/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the minimal permissions required for the workflow to function. Since the workflow only checks out code and runs build/test commands, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This can be set at the workflow level (top-level, just after the `name:` and before `on:`), which will apply to all jobs unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
