### PR TITLE
Fix this test to work correctly on August 1 2025 onwards

### DIFF
--- a/tests/dir_entries.aria
+++ b/tests/dir_entries.aria
@@ -20,9 +20,21 @@ func main() {
     assert entries[0].exists();
     assert entries[0].get_extension() == "aria";
 
+    println("Created {0} ms since epoch".format(entries[0].creation_ms_since_epoch()));
+
     val creation = Instant.from_unix_timestamp(entries[0].creation_ms_since_epoch());
 
     assert creation.year >= 2025;
-    assert creation.month >= 7;
-    assert creation.day >= 4;
+    if creation.year == 2025 {
+        assert creation.month >= 7;
+
+        if creation.month == 7 {
+            assert creation.day >= 4;
+        } else {
+            assert creation.day >= 1;
+        }
+    } else {
+        assert creation.month >= 1;
+        assert creation.day >= 1;
+    }
 }


### PR DESCRIPTION
Turns out it will not always be a day greater >= 4 and a month >= 7

For example Aug 1st 2025 is not day >= 4 and Jan 1st 2026 is not month >= 7
but both of those days come aftr July 4th 2025, which is what this test
was poorly trying to evaluate

Just make sure the creation parameters are somewhat reasonable and move on
If some timestamp breaks the Instant API, it should be fixed and tested in
the Instant API, not here
