### PR TITLE
Optimize PUSH/JUMP pairs

### DIFF
--- a/vm-lib/src/builtins/timezone.rs
+++ b/vm-lib/src/builtins/timezone.rs
@@ -30,7 +30,7 @@ impl BuiltinFunctionImpl for TimezoneInfo {
             tm_yday: 0,
             tm_isdst: 0,
             tm_gmtoff: 0,
-            tm_zone: std::ptr::null(),
+            tm_zone: std::ptr::null_mut(),
         };
         unsafe {
             libc::localtime_r(&now, &mut tm);


### PR DESCRIPTION
Closes #62. 
Running [for_else.aria](https://github.com/enricobolzonello/aria/blob/master/tests/for_else.aria):
- Before optimization: [before.txt](https://github.com/user-attachments/files/21605697/before.txt)
- After optimization: [after.txt](https://github.com/user-attachments/files/21605720/after.txt)
Also fixes tm_zone pointer type in timezone info struct, which was wrongly instantiated as immutable.