### PR TITLE
Rename the "Rust" workflow to "LinuxBuildAndTest"

### DIFF
--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: LinuxBuildAndTest
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Aria: A Fresh, Safe, and Flexible Language for High-Level Development
-[![Build Status](https://github.com/egranata/aria/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/egranata/aria/actions/workflows/rust.yml)
+[![Linux Build](https://github.com/egranata/aria/actions/workflows/linux_build_test.yml/badge.svg?branch=master)](https://github.com/egranata/aria/actions/workflows/linux_build_test.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Docs](https://img.shields.io/badge/Docs-Available-blue.svg)](https://egranata.github.io/aria/)
 [![Contributors](https://img.shields.io/github/contributors/egranata/aria)](https://github.com/egranata/aria/graphs/contributors)


### PR DESCRIPTION
If we are going to add a macOS target, we need a separate action for Mac, so
start preparing by giving the existing workflow a more useful name
