### PR TITLE
Improvements to prebuilt packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: write
 name: release
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      BIN_TARGETS: "aria"
+      DYLIB_CRATES: "aria_file aria_http aria_path aria_platform aria_regex"
+      EXTRA_FILES: ""
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build + package
+        shell: bash
+        run: ./package.sh
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            *.tgz
+            *.tgz.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ members = [
 ]
 resolver = "2"
 
-[profile.release]
+[profile.dist]
+inherits = "release"
 codegen-units = 1
 lto = "fat"
+
+[profile.release]
+lto = "thin"
+

--- a/package.sh
+++ b/package.sh
@@ -14,7 +14,7 @@ HOST_TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
 LIB_PREFIX="lib"
 LIB_EXT="so"
 case "$RUNOS" in
-  macOS)   LIB_PREFIX="lib"; LIB_EXT="dylib" ;;
+  macOS|Darwin)   LIB_PREFIX="lib"; LIB_EXT="dylib" ;;
   Linux)   LIB_PREFIX="lib"; LIB_EXT="so" ;;
 esac
 

--- a/package.sh
+++ b/package.sh
@@ -1,11 +1,18 @@
 set -euo pipefail
 
-BIN_TARGETS="${BIN_TARGETS:aria}"
-DYLIB_CRATES="${DYLIB_CRATES:aria_file aria_http aria_path aria_platform aria_regex}"
+BIN_TARGETS="${BIN_TARGETS:-aria}"
+DYLIB_CRATES="${DYLIB_CRATES:-aria_file aria_http aria_path aria_platform aria_regex}"
 EXTRA_FILES="${EXTRA_FILES:-}"
 
 NAME="aria"
-VER=`awk '/^\[package\]/{p=1;next} /^\[/{p=0} p && $1=="version" {match($0, /"([^"]+)"/, m); print m[1]; exit}' aria-bin/Cargo.toml`
+VER=`awk '/^\[package\]/{p=1;next} /^\[/{p=0}
+     p && $1=="version" {
+       if (match($0, /"[^"]+"/)) {
+         v=substr($0, RSTART+1, RLENGTH-2) # strip quotes
+         print v
+         exit
+       }
+     }' aria-bin/Cargo.toml`
 TS="$(date -u +%Y%m%d%H%M%S)"
 
 RUNOS="${RUNNER_OS:-$(uname -s)}"

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,73 @@
+set -euo pipefail
+
+BIN_TARGETS="aria"
+DYLIB_CRATES="aria_file aria_http aria_path aria_platform aria_regex"
+EXTRA_FILES=""
+
+NAME="aria"
+VER=`awk '/^\[package\]/{p=1;next} /^\[/{p=0} p && $1=="version" {match($0, /"([^"]+)"/, m); print m[1]; exit}' aria-bin/Cargo.toml`
+TS="$(date -u +%Y%m%d%H%M%S)"
+
+RUNOS="${RUNNER_OS:-$(uname -s)}"
+HOST_TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
+
+LIB_PREFIX="lib"
+LIB_EXT="so"
+case "$RUNOS" in
+  macOS)   LIB_PREFIX="lib"; LIB_EXT="dylib" ;;
+  Linux)   LIB_PREFIX="lib"; LIB_EXT="so" ;;
+esac
+
+cargo build --workspace --release
+./t
+
+STAGING_ROOT="$(mktemp -d)"
+trap 'rm -rf "$STAGING_ROOT"' EXIT
+ARCHIVE_DIR="${NAME}-${VER}-${HOST_TRIPLE}"
+DEST="$STAGING_ROOT/$ARCHIVE_DIR"
+
+if [[ -n "$BIN_TARGETS" ]]; then
+  for b in $BIN_TARGETS; do
+    src="target/release/${b}"
+    [[ -f "$src" ]] || { echo "Missing binary: $src" >&2; exit 2; }
+    mkdir -p "$DEST/bin"
+    cp -v "$src" "$DEST/bin/"
+  done
+else
+  echo "No binaries specified to be copied" >&2; exit 2;
+fi
+
+if [[ -n "$DYLIB_CRATES" ]]; then
+  for c in $DYLIB_CRATES; do
+    libname="${LIB_PREFIX}${c}.${LIB_EXT}"
+    src="target/release/${libname}"
+    [[ -f "$src" ]] || { echo "Missing cdylib: $src" >&2; exit 3; }
+    mkdir -p "$DEST/bin"
+    cp -v "$src" "$DEST/bin/"
+  done
+fi
+
+[[ -d lib ]] && mkdir -p "$DEST/lib" && cp -a lib/. "$DEST/lib/"
+
+if [[ -n "$EXTRA_FILES" ]]; then
+  shopt -s nullglob dotglob
+  for f in $EXTRA_FILES; do
+    mkdir -p "$DEST/bin" "$DEST/lib" "$DEST/share"
+    [[ -e "$f" ]] || { echo "Skipping missing: $f" >&2; continue; }
+    cp -av "$f" "$DEST/share/"
+  done
+  shopt -u nullglob dotglob
+fi
+
+ARCHIVE="${ARCHIVE_DIR}-${TS}.tgz"
+tar -C "$STAGING_ROOT" -czf "$ARCHIVE" "$ARCHIVE_DIR"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
+elif command -v shasum >/dev/null 2>&1; then
+  shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
+elif command -v certutil >/dev/null 2>&1; then
+  certutil -hashfile "$ARCHIVE" SHA256 | sed -n '1p' > "${ARCHIVE}.sha256"
+fi
+
+echo "Built: $ARCHIVE"

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,7 @@
 set -euo pipefail
 
+PROFILE=${PROFILE:-dist}
+
 BIN_TARGETS="${BIN_TARGETS:-aria}"
 DYLIB_CRATES="${DYLIB_CRATES:-aria_file aria_http aria_path aria_platform aria_regex}"
 EXTRA_FILES="${EXTRA_FILES:-}"
@@ -25,8 +27,8 @@ case "$RUNOS" in
   Linux)   LIB_PREFIX="lib"; LIB_EXT="so" ;;
 esac
 
-cargo build --workspace --release
-./t
+cargo build --workspace --profile "$PROFILE"
+ARIA_BUILD_CONFIG=${PROFILE} ./t
 
 STAGING_ROOT="$(mktemp -d)"
 trap 'rm -rf "$STAGING_ROOT"' EXIT
@@ -35,7 +37,7 @@ DEST="$STAGING_ROOT/$ARCHIVE_DIR"
 
 if [[ -n "$BIN_TARGETS" ]]; then
   for b in $BIN_TARGETS; do
-    src="target/release/${b}"
+    src="target/${PROFILE}/${b}"
     [[ -f "$src" ]] || { echo "Missing binary: $src" >&2; exit 2; }
     mkdir -p "$DEST/bin"
     cp -v "$src" "$DEST/bin/"
@@ -47,7 +49,7 @@ fi
 if [[ -n "$DYLIB_CRATES" ]]; then
   for c in $DYLIB_CRATES; do
     libname="${LIB_PREFIX}${c}.${LIB_EXT}"
-    src="target/release/${libname}"
+    src="target/${PROFILE}/${libname}"
     [[ -f "$src" ]] || { echo "Missing cdylib: $src" >&2; exit 3; }
     mkdir -p "$DEST/bin"
     cp -v "$src" "$DEST/bin/"

--- a/package.sh
+++ b/package.sh
@@ -1,8 +1,8 @@
 set -euo pipefail
 
-BIN_TARGETS="aria"
-DYLIB_CRATES="aria_file aria_http aria_path aria_platform aria_regex"
-EXTRA_FILES=""
+BIN_TARGETS="${BIN_TARGETS:aria}"
+DYLIB_CRATES="${DYLIB_CRATES:aria_file aria_http aria_path aria_platform aria_regex}"
+EXTRA_FILES="${EXTRA_FILES:-}"
 
 NAME="aria"
 VER=`awk '/^\[package\]/{p=1;next} /^\[/{p=0} p && $1=="version" {match($0, /"([^"]+)"/, m); print m[1]; exit}' aria-bin/Cargo.toml`

--- a/package.sh
+++ b/package.sh
@@ -57,6 +57,10 @@ if [[ -n "$DYLIB_CRATES" ]]; then
 fi
 
 [[ -d lib ]] && mkdir -p "$DEST/lib" && cp -a lib/. "$DEST/lib/"
+[[ -d examples ]] && mkdir -p "$DEST/share/examples" && cp -a examples/. "$DEST/share/examples"
+[[ -f docs/manual.md ]] && mkdir -p "$DEST/share/docs" && cp -a docs/manual.md "$DEST/share/docs"
+[[ -f docs/stdlib.md ]] && mkdir -p "$DEST/share/docs" && cp -a docs/stdlib.md "$DEST/share/docs"
+[[ -f docs/style_guide.md ]] && mkdir -p "$DEST/share/docs" && cp -a docs/style_guide.md "$DEST/share/docs"
 
 if [[ -n "$EXTRA_FILES" ]]; then
   shopt -s nullglob dotglob


### PR DESCRIPTION
- **Create a script that will package up a build of Aria into a .tgz file**
- **Create a github workflow to package Aria releases when a new tag is pushed**
- **Add write permission to workflow**
- **macOS' uname -s returns Darwin, not macOS**
- **Fix awk command not working in macos**
- **Introduce dist/release profile**
- **Add docs and examples to the Aria prebuilt packages**
