### PR TITLE
Make it so that identifiers that begin with assert can be used as functions

### DIFF
--- a/parser-lib/src/grammar/grammar.pest
+++ b/parser-lib/src/grammar/grammar.pest
@@ -120,10 +120,10 @@ expr_stmt     = { expression? ~ ";" }
 throw_stmt = { "throw" ~ expression ~ ";" }
 
 statement = {
-    assert_stmt
-  | break_stmt
+    break_stmt
   | continue_stmt
   | expr_stmt
+  | assert_stmt
   | val_write_stmt
   | val_decl_stmt
   | val_add_eq_write

--- a/tests/assert_id_func.aria
+++ b/tests/assert_id_func.aria
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+val called = false;
+
+func assert_test(x,y) {
+    called = true;
+    assert x == y;
+}
+
+func main() {
+    assert !called;
+    assert_test(3,3);
+    assert called;
+}


### PR DESCRIPTION
Fixes #106