### PR TITLE
Fix: replace self.msg with this.msg in Request.Error::prettyprint

### DIFF
--- a/lib/aria/network/request.aria
+++ b/lib/aria/network/request.aria
@@ -20,7 +20,7 @@ struct Request {
         }
 
         func prettyprint() {
-            return "network error: {0}".format(self.msg);
+            return "network error: {0}".format(this.msg);
         }
     }
 


### PR DESCRIPTION
Fixed the use of self.msg in Request.Error::prettyprint instead of this.msg

The following piece of code:

```
import Request from aria.network.request;

func main() {
    val response = Request.new("https://google.com/").get();
    println(response);
    
    val response = Request.new("https://pls.dont.exist.com/").get();
    println(response);
    
    match response {
        case Ok(response) => {
            println(response);
        },
        case Err(error) => {
            println(error);
        }
    }
}
```
Was giving the output:

```
Ok(aria.network.Request.Response(code=200))
<enum-value of type Result>
<object of type Error>
```

Looks like, instead of an error when finding a wrong identifier or missing function, the vm just stops execution. This causes functions to partially execute, they don't reach their return clause so no value is pushed to the stack. If you don't have an issue addressing this I am opening one.

Example:

```
func prettyprint() {
        prinaaaa(); # No error here and the VM looks like stops execution
        return "network error: {0}".format(this.msg);
}
```

With the change the output looks like this:

```
Ok(aria.network.Request.Response(code=200))
Err(network error: error sending request for url (https://pls.dont.exist.com/))
network error: error sending request for url (https://pls.dont.exist.com/)
```