### PR TITLE
Implement Path.hash - simply hash the underlying String representation

### DIFF
--- a/lib/aria/io/path.aria
+++ b/lib/aria/io/path.aria
@@ -91,4 +91,8 @@ struct Path {
     func copy_to(other: Path) {
         this._copy(other);
     }
+
+    func hash() {
+        return this.prettyprint().hash();
+    }
 }

--- a/tests/path_hash.aria
+++ b/tests/path_hash.aria
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+import Path from aria.io.path;
+
+func main() {
+    val p1 = Path.new("/some/test/path");
+    val p2 = Path.new("/some/test/path");
+
+    assert p1.hash() == p2.hash();
+    assert p1.hash() == p1.hash();
+
+    val p3 = p1  / "subdir" / "file.txt";
+    val p4 = Path.new("/some/test/path/subdir/file.txt");
+    
+    assert p3.hash() == p4.hash();
+    assert p3.hash() != p1.hash();
+}


### PR DESCRIPTION
Fixes #268