### PR TITLE
Treat hex literals as unsigned bit patterns

### DIFF
--- a/aria-bin/src/test.rs
+++ b/aria-bin/src/test.rs
@@ -259,3 +259,17 @@ fn repl_test_printf() {
         &["hello = 42 hi = 43\n"],
     );
 }
+
+#[test]
+fn repl_test_invalid_literal() {
+    let cmdline_options = Args::default();
+    let mut repl = build_test_repl(&cmdline_options);
+
+    run_check_repl_line(
+        &mut repl,
+        "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+        false,
+        &["0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF is not a valid literal"],
+        &[],
+    );
+}

--- a/compiler-lib/src/do_compile/nodes/int_literal.rs
+++ b/compiler-lib/src/do_compile/nodes/int_literal.rs
@@ -1,25 +1,55 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     constant_value::ConstantValue,
-    do_compile::{CompilationResult, CompileNode, CompileParams},
+    do_compile::{
+        CompilationError, CompilationErrorReason, CompilationResult, CompileNode, CompileParams,
+    },
     func_builder::BasicBlockOpcode,
 };
 
 impl<'a> CompileNode<'a> for aria_parser::ast::IntLiteral {
     fn do_compile(&self, params: &'a mut CompileParams) -> CompilationResult {
-        if self.val == 0 {
+        let inp_str = &self.val.replace('_', "");
+
+        // I don't particularly like this code, but I don't know an easy way to write
+        // if X { Result<A,E> } else if XX { Result<B,E> } ... . map_err(...)? as B;
+        // basically, some paths want to generate a u64 and some want to generate an i64,
+        // but all need to converge on i64 in the end.
+        let val = if let Some(hex_str) = inp_str.strip_prefix("0x") {
+            u64::from_str_radix(hex_str, 16).map_err(|_| CompilationError {
+                loc: self.loc.clone(),
+                reason: CompilationErrorReason::InvalidLiteral(inp_str.to_owned()),
+            })? as i64
+        } else if let Some(bin_str) = inp_str.strip_prefix("0b") {
+            u64::from_str_radix(bin_str, 2).map_err(|_| CompilationError {
+                loc: self.loc.clone(),
+                reason: CompilationErrorReason::InvalidLiteral(inp_str.to_owned()),
+            })? as i64
+        } else if let Some(oct_str) = inp_str.strip_prefix("0o") {
+            i64::from_str_radix(oct_str, 8).map_err(|_| CompilationError {
+                loc: self.loc.clone(),
+                reason: CompilationErrorReason::InvalidLiteral(inp_str.to_owned()),
+            })?
+        } else {
+            inp_str.parse::<i64>().map_err(|_| CompilationError {
+                loc: self.loc.clone(),
+                reason: CompilationErrorReason::InvalidLiteral(inp_str.to_owned()),
+            })?
+        };
+
+        if val == 0 {
             params
                 .writer
                 .get_current_block()
                 .write_opcode_and_source_info(BasicBlockOpcode::Push0, self.loc.clone());
-        } else if self.val == 1 {
+        } else if val == 1 {
             params
                 .writer
                 .get_current_block()
                 .write_opcode_and_source_info(BasicBlockOpcode::Push1, self.loc.clone());
         } else {
             let const_idx =
-                self.insert_const_or_fail(params, ConstantValue::Integer(self.val), &self.loc)?;
+                self.insert_const_or_fail(params, ConstantValue::Integer(val), &self.loc)?;
             params
                 .writer
                 .get_current_block()

--- a/lib/aria/range/range.aria
+++ b/lib/aria/range/range.aria
@@ -91,11 +91,11 @@ struct RangeImpl {
     }
 
     func hash() {
-        val h = this.from ^ (this.to + -7046029254386353131);
+        val h = this.from ^ (this.to + 0x9e3779b97f4a7c15);
         h = h ^ (h >> 30);
-        h = h * -4658895280553007687;
+        h = h * 0xbf58476d1ce4e5b9;
         h = h ^ (h >> 27);
-        h = h * -7723592293110705685;
+        h = h * 0x94d049bb133111eb;
         h = h ^ (h >> 31);
         return h;
     }

--- a/parser-lib/src/ast/mod.rs
+++ b/parser-lib/src/ast/mod.rs
@@ -162,7 +162,7 @@ impl From<&InputLocation> for Location {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntLiteral {
     pub loc: SourcePointer,
-    pub val: i64,
+    pub val: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/parser-lib/src/ast/nodes/int_literal.rs
+++ b/parser-lib/src/ast/nodes/int_literal.rs
@@ -1,30 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
-use crate::{
-    ast::{
-        IntLiteral, SourceBuffer,
-        derive::Derive,
-        prettyprint::{PrettyPrintable, printout_accumulator::PrintoutAccumulator},
-    },
-    grammar::Rule,
+use crate::ast::{
+    IntLiteral,
+    derive::Derive,
+    prettyprint::{PrettyPrintable, printout_accumulator::PrintoutAccumulator},
 };
 
 impl Derive for IntLiteral {
-    fn from_parse_tree(p: pest::iterators::Pair<'_, Rule>, source: &SourceBuffer) -> Self {
-        assert!(p.as_rule() == Rule::int_literal);
+    fn from_parse_tree(
+        p: pest::iterators::Pair<'_, crate::grammar::Rule>,
+        source: &crate::ast::SourceBuffer,
+    ) -> Self {
+        assert!(p.as_rule() == crate::grammar::Rule::int_literal);
         let loc = From::from(&p.as_span());
-        let inp_str = p.as_str().to_owned().replace('_', "");
-
-        let val = if let Some(hex_str) = inp_str.strip_prefix("0x") {
-            i64::from_str_radix(hex_str, 16)
-        } else if let Some(bin_str) = inp_str.strip_prefix("0b") {
-            i64::from_str_radix(bin_str, 2)
-        } else if let Some(oct_str) = inp_str.strip_prefix("0o") {
-            i64::from_str_radix(oct_str, 8)
-        } else {
-            inp_str.parse::<i64>()
-        }
-        .expect("invalid literal");
-
+        let val = p.as_str().to_owned();
         Self {
             loc: source.pointer(loc),
             val,
@@ -34,6 +22,6 @@ impl Derive for IntLiteral {
 
 impl PrettyPrintable for IntLiteral {
     fn prettyprint(&self, buffer: PrintoutAccumulator) -> PrintoutAccumulator {
-        buffer << &self.val
+        buffer.write(&self.val)
     }
 }

--- a/tests/large_hex_int.aria
+++ b/tests/large_hex_int.aria
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+val n = 0x94d049bb133111eb;
+assert n == -7723592293110705685;


### PR DESCRIPTION
Fixes #294
