### PR TITLE
    Swap the order of assignment in the bytecode

### DIFF
--- a/compiler-lib/src/do_compile/mod.rs
+++ b/compiler-lib/src/do_compile/mod.rs
@@ -628,6 +628,7 @@ fn emit_type_val_decl_compile(
     params
         .writer
         .get_current_block()
+        .write_opcode_and_source_info(BasicBlockOpcode::Swap, vd.loc.clone())
         .write_opcode_and_source_info(BasicBlockOpcode::WriteAttribute(name_idx), vd.loc.clone());
     Ok(())
 }
@@ -659,6 +660,7 @@ fn emit_type_members_compile(
                 params
                     .writer
                     .get_current_block()
+                    .write_opcode_and_source_info(BasicBlockOpcode::Swap, sd.loc.clone())
                     .write_opcode_and_source_info(
                         BasicBlockOpcode::WriteAttribute(name_idx),
                         sd.loc.clone(),
@@ -674,6 +676,10 @@ fn emit_type_members_compile(
                         .writer
                         .get_current_block()
                         .write_opcode_and_source_info(BasicBlockOpcode::Copy(1), ed.loc.clone());
+                    params
+                        .writer
+                        .get_current_block()
+                        .write_opcode_and_source_info(BasicBlockOpcode::Swap, ed.loc.clone());
 
                     let name_idx = ed.insert_const_or_fail(
                         params,

--- a/compiler-lib/src/do_compile/postfix.rs
+++ b/compiler-lib/src/do_compile/postfix.rs
@@ -152,13 +152,24 @@ impl<'a> PostfixValue {
                                 .writer
                                 .get_current_block()
                                 .write_opcode_and_source_info(
+                                    BasicBlockOpcode::Swap,
+                                    term.loc().clone(),
+                                )
+                                .write_opcode_and_source_info(
                                     BasicBlockOpcode::WriteAttribute(identifier_idx),
                                     term.loc().clone(),
                                 );
                         }
                         ObjWrite::Index(index_write) => {
-                            index_write.index.do_compile(params)?;
                             index_write.value.do_compile(params)?;
+                            params
+                                .writer
+                                .get_current_block()
+                                .write_opcode_and_source_info(
+                                    BasicBlockOpcode::Swap,
+                                    term.loc().clone(),
+                                );
+                            index_write.index.do_compile(params)?;
                             params
                                 .writer
                                 .get_current_block()
@@ -243,9 +254,9 @@ impl<'a> PostfixValue {
                 reason: CompilationErrorReason::ReadOnlyValue,
             }),
             PostfixValue::Index(base, index) => {
+                val.do_compile(params)?;
                 base.emit_read(params)?;
                 index.do_compile(params)?;
-                val.do_compile(params)?;
                 params
                     .writer
                     .get_current_block()
@@ -269,8 +280,8 @@ impl<'a> PostfixValue {
                         });
                     }
                 };
-                base.emit_read(params)?;
                 val.do_compile(params)?;
+                base.emit_read(params)?;
                 params
                     .writer
                     .get_current_block()

--- a/tests/obj_write_comprehensive.aria
+++ b/tests/obj_write_comprehensive.aria
@@ -2,4 +2,4 @@
 val t = [];
 func rec(i) { t.append(i); return i; }
 val o = [] { [rec(0)] = rec(1), [rec(1)] = rec(2) };
-assert t == [0,1,1,2];
+assert t == [1,0,2,1];

--- a/vm-lib/src/vm.rs
+++ b/vm-lib/src/vm.rs
@@ -1036,13 +1036,13 @@ impl VirtualMachine {
                 }
             }
             Opcode::WriteIndex(n) => {
-                let val = pop_or_err!(next, frame, op_idx);
                 let mut indices = Vec::<_>::with_capacity(n as usize);
                 for _ in 0..n {
                     let idx = pop_or_err!(next, frame, op_idx);
                     indices.insert(0, idx);
                 }
                 let cnt = pop_or_err!(next, frame, op_idx);
+                let val = pop_or_err!(next, frame, op_idx);
                 match cnt.write_index(&indices, &val, frame, self) {
                     Ok(crate::runtime_value::CallResult::OkNoValue)
                     | Ok(crate::runtime_value::CallResult::Ok(_)) => {}
@@ -1094,8 +1094,8 @@ impl VirtualMachine {
                 }
             }
             Opcode::WriteAttribute(n) => {
-                let val = pop_or_err!(next, frame, op_idx);
                 let obj = pop_or_err!(next, frame, op_idx);
+                let val = pop_or_err!(next, frame, op_idx);
                 let attr_name = if let Some(ct) = this_module.load_indexed_const(n) {
                     if let Some(sv) = ct.as_string() {
                         sv.clone()


### PR DESCRIPTION
    Instead of popping <rvalue>, <lvalue> do <lvalue>, <rvalue>

    That makes it easier to describe multiple assignments because you end up with

    <rvalue>
    <rvalue>
    <rvalue>

    then you push <lvalue>, so you have

    <rvalue>... <rvalue>, <lvalue> and so you pop <lvalue>, <rvalue> ...

    The unfortunate thing is that this introduces a bunch of Swap opcodes in the
    compiler's output, which I would prefer to avoid
