### PR TITLE
added permissions, token ref,and correct command names for full workflow

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,7 +2,7 @@ name: Run Clippy on PR
 
 on:
   repository_dispatch:
-    types: [clippy]
+    types: [clippy-command]
 
 permissions:
   contents: write

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -2,7 +2,7 @@ name: Format PR with cargo fmt
 
 on:
   repository_dispatch:
-    types: [fmt]
+    types: [fmt-command]
 
 # Needs write to push a commit
 permissions:

--- a/.github/workflows/slash_clippy.yml
+++ b/.github/workflows/slash_clippy.yml
@@ -13,11 +13,14 @@ jobs:
   dispatch:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/clippy') }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: peter-evans/slash-command-dispatch@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SLASH_COMMAND_PAT }}
+          reaction-token: ${{ secrets.SLASH_COMMAND_PAT }}
           commands: clippy
           dispatch-type: repository
           issue-type: pull-request

--- a/.github/workflows/slash_fmt.yml
+++ b/.github/workflows/slash_fmt.yml
@@ -16,12 +16,15 @@ jobs:
   dispatch:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/fmt') }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: peter-evans/slash-command-dispatch@v4
         with:
           # Use GITHUB_TOKEN now that it has write perms
-          token: ${{ secrets.GITHUB_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SLASH_COMMAND_PAT  }}
+          reaction-token: ${{ secrets.SLASH_COMMAND_PAT  }}
           commands: fmt
           dispatch-type: repository
           issue-type: pull-request


### PR DESCRIPTION
Finally got this working. I tested it out on my fork and even verified with a new github account that these commands will work on PRs from Forks.

Issues addressed: 

1. peterevans dispatch command requires the suffix -command to any command (that's why the parent workflows weren't running)

2. Added a repo-scoped token with the following permissions. (SLASH_COMMAND_PAT)

    Actions- W/R
    Contents - W/R (this was the least intuitive but I guess it needs Write to react)
    Issues - W/R
    Pull Requests - W/R
    Workflows - W/R
    
I need an owner of the repo to add a token with that name to Settings -> Secrets and Variables -> Actions.
by default, GITHUB_TOKEN can't run CI on PRs from forks for security reasons

I will say that aria/bin/test.rs and vm-lib did not pass clippy but that is not the fault of the CI, that's desired behavior. See the log attached here.
[clippy_output.txt](https://github.com/user-attachments/files/23294728/clippy_output.txt)

Please add that token, then we can merge these and have fully working /fmt and /clippy commands 😎 