### PR TITLE
fix slash_fmt so it doesn't commit to avoid failures

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,12 +1,11 @@
-name: Format PR with cargo fmt
+name: Check PR Formatting with cargo fmt
 
 on:
   repository_dispatch:
     types: [fmt-command]
 
-# Needs write to push a commit
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
@@ -20,22 +19,11 @@ jobs:
           echo "ref=${{ github.event.client_payload.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
           echo "number=${{ github.event.client_payload.pull_request.number }}" >> "$GITHUB_OUTPUT"
 
-      # Use a repo-scoped PAT for forks, else fall back to GITHUB_TOKEN
-      - name: Set push token
-        id: token
-        run: |
-          if [ -n "${{ secrets.REPO_SCOPED_TOKEN }}" ]; then
-            echo "token=${{ secrets.REPO_SCOPED_TOKEN }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "token=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.pr.outputs.repo }}
           ref: ${{ steps.pr.outputs.ref }}
-          token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
 
       - name: Install Rust (stable + rustfmt)
@@ -44,25 +32,20 @@ jobs:
           components: rustfmt
 
       - name: Run cargo fmt
-        run: cargo fmt --all
-
-      - name: Commit changes if any
+        id: fmt
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            git config user.name "gh-actions"
-            git config user.email "actions@users.noreply.github.com"
-            git add -A
-            git commit -m "chore(fmt): apply cargo fmt via /fmt"
-            git push origin "HEAD:${{ steps.pr.outputs.ref }}"
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "No formatting changes"
-          fi
+          cargo fmt --all -- --check || echo "changes_needed=true" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ steps.token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.pr.outputs.number }}
           body: |
-            ✅ `cargo fmt` completed on `${{ steps.pr.outputs.ref }}`. Changes were pushed if any.
+            ✅ `cargo fmt` completed on `${{ steps.pr.outputs.ref }}`.
+
+            ${{ 
+              steps.fmt.outputs.changes_needed == 'true' && '❌ Formatting issues detected. Please run `cargo fmt --all` locally and push the fixes.' || 
+              '🎉 Code is properly formatted. No action needed.'
+            }}
+


### PR DESCRIPTION
After seeing the run failures on the upstream from trying to commit to downstream forks, I realized that we conceptually had this wrong from the start.

Now that we are in an org, every PR will come from a fork. Github's action bot can't commit downstream onto forks for obvious reasons. Additionally, in my testing, I found that CI fails if the code isn't formatted.

We should all also be using the pre commit hooks. I had to bypass them to test this worflow. 

Because of all of that, I decided to:

1. Remove the commit and push step.
2. Comment if fmt was successful or not
3. Request from the PR originator to run cargo fmt locally and recommit

This will avoid run failures as we saw in the previous iteration which is top priority from my standpoint- CI and pre-commit hooks already safeguard against non-idiomatically formatted Rust code.

Use case: If CI fails, run this check. That will tell us quickly and easily whether this is a fmt issue or not. If not, then we can check the CI logs.

Less handy than slash_clippy but it is still useful and won't pollute the inbox with run failure messages