### PR TITLE
Update release action with automated homebrew tap update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Update homebrew tap
         run: gh workflow run main.yml -f version=${{ env.VERSION }} -R arialang/homebrew-aria
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This step runs the Github action in https://github.com/arialang/homebrew-aria to update the homebrew formula. 