### PR TITLE
Update release workflow with github app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
       EXTRA_FILES: "CHANGELOG.md"
       CARGO_TERM_COLOR: always
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ariahomebrewreleaseapp }}
+          private-key: ${{ secrets.ariahomebrewreleaseapp }}
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Get version
@@ -34,6 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update homebrew tap
+        continue-on-error: true
         run: gh workflow run main.yml -f version=${{ env.VERSION }} -R arialang/homebrew-aria
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Closes #370. I've not managed to test it since I dont have permissions (@egranata). In any case, I've added the continue on error so it doesnt block the workflow