### PR TITLE
Change String.hash() so anagrams don't produce the same output

### DIFF
--- a/lib/aria/core/string.aria
+++ b/lib/aria/core/string.aria
@@ -195,7 +195,7 @@ extension String {
     func hash() {
         val ret = 0;
         for b in this.bytes() {
-            ret += 31 * b;
+            ret = 31 * ret + b;
         }
 
         return ret;

--- a/tests/strings_anagram_hash.aria
+++ b/tests/strings_anagram_hash.aria
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+assert "listen".hash() != "silent".hash();
+
+assert "".hash() == "".hash();
+
+assert "a".hash() != "A".hash();


### PR DESCRIPTION
Fixes #440
